### PR TITLE
Days since repo was created

### DIFF
--- a/src/components/TrendingReposListItem.vue
+++ b/src/components/TrendingReposListItem.vue
@@ -24,7 +24,7 @@
                         <div class="text-sm py-1 px-2 rounded mr-2 border border-green-300 text-green-600 hover:bg-green-200">Stars: {{starsCount}}</div>
                         <div class="text-sm py-1 px-2 rounded border border-red-300 text-red-600 hover:bg-red-200">Issues: {{issuesCount}}</div>
                     </div>
-                    <div class="text-sm italic">Submited {{createdAt}} days ago by {{ownerName}}</div>
+                    <div class="text-sm italic">Submited {{daysFormatter}} ago by {{ownerName}}</div>
                 </div>
             </div>
         </a>
@@ -34,6 +34,7 @@
 
 <script>
 import { ref, computed, toRefs } from "vue";
+import daysFormatterHelperFunction from  "../composables/daysFormatter";
 
 export default {
     name: "TrendingReposListItem",
@@ -49,16 +50,19 @@ export default {
         index: Number
     },
     setup(props) {
-        const { index } = toRefs(props);
+        const { index, createdAt } = toRefs(props);
         const showLabel = ref(false)
 
         const isEven = computed(() => {
             return index.value % 2;
         })
 
+        const { daysFormatter } = daysFormatterHelperFunction(createdAt)
+
         return {
             isEven,
-            showLabel
+            showLabel,
+            daysFormatter,
         }
     }
 }

--- a/src/composables/daysFormatter.js
+++ b/src/composables/daysFormatter.js
@@ -1,0 +1,26 @@
+
+import { computed } from "vue";
+
+export default function daysFormatterHelperFunction(createdAt) {
+       
+    const currentDate = new Date();
+  
+    const differenceInTime = currentDate.getTime() - new Date(createdAt.value).getTime();
+
+    const daysSinceRepoWasCreated = (differenceInTime / (1000 * 3600 * 24))
+
+    const daysFormatter = computed(() => {
+        if(daysSinceRepoWasCreated < 365) {
+            return daysSinceRepoWasCreated + " days"
+        } else if(daysSinceRepoWasCreated >= 365 && daysSinceRepoWasCreated  < 729) {
+            return "Over 1 year"
+        } else if(daysSinceRepoWasCreated >= 730) {
+            return "Over 2 years"
+        }
+        return ''
+    })
+
+    return {
+        daysFormatter
+    }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -2,4 +2,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import './index.css'
 
-createApp(App).mount('#app')
+const app = createApp(App);
+
+app
+    .mount('#app')


### PR DESCRIPTION
**What** 
I created a helper function that returns the number of days since the repository was created. Repositories posted over a year ago but less than 2 years ago are returned as **over 1 year ago**, while those posted from 2 years and above are returned as **over 2years ago.**

**Why**
Based on the mockup design of the task, the date since the repository was created was formatted instead of displayed as is. This is necessary for a better user interface design.

**How**
I created a composable function that finds the difference in days between the current date and the date the repository was posted
